### PR TITLE
move pledge after unveil

### DIFF
--- a/Porcelain
+++ b/Porcelain
@@ -808,13 +808,6 @@ sub readconf {	# filename of file with keys and values separated by ':'--> hash 
 Net::SSLeay::initialize();	# initialize ssl library once
 
 if ($^O eq 'openbsd') {
-	# TODO: tighten pledge later, e.g. remove wpath rpath after config is read
-	#	sslcat_custom:			rpath inet dns
-	#	system (for external programs)	exec proc
-	#	Curses				tty
-	# prot_exec is needed, as sometimes abort trap gets triggered when loading pages without it
-	pledge(qw ( exec tty cpath rpath wpath inet dns proc prot_exec unveil ) ) || die "Unable to pledge: $!";
-
 	# TODO: tighten unveil later
 	unveil( "$ENV{'HOME'}/Downloads", "rwc") || die "Unable to unveil: $!";
 	unveil( "/usr/local/libdata/perl5/site_perl/amd64-openbsd/auto/Net/SSLeay", "r") || die "Unable to unveil: $!";
@@ -830,7 +823,13 @@ if ($^O eq 'openbsd') {
 		my $unveil_bin = $v =~ s/\s.*$//r;	# this way parameters to the programs will not mess up the call.
 		unveil( $unveil_bin, "x") || die "Unable to unveil: $!";
 	}
-	unveil() || die "Unable to lock unveil: $!";
+
+	# TODO: tighten pledge later, e.g. remove wpath rpath after config is read
+	#	sslcat_custom:			rpath inet dns
+	#	system (for external programs)	exec proc
+	#	Curses				tty
+	# prot_exec is needed, as sometimes abort trap gets triggered when loading pages without it
+	pledge(qw ( exec tty cpath rpath wpath inet dns proc prot_exec ) ) || die "Unable to pledge: $!";
 }
 
 # process user input


### PR DESCRIPTION
This way, it's possible to drop the `unveil` plege(2) promise and the empty unveil call.